### PR TITLE
feature: add name property to Graph model

### DIFF
--- a/src/nessie_api/models/graph.py
+++ b/src/nessie_api/models/graph.py
@@ -113,7 +113,9 @@ class Edge:
 
 class Graph:
 
-    def __init__(self, graph_type: GraphType = GraphType.DIRECTED) -> None:
+    def __init__(self, name: str, graph_type: GraphType = GraphType.DIRECTED) -> None:
+        self.name = name
+
         self.graph_type = graph_type
 
         self._nodes: dict[str, Node] = {}
@@ -236,6 +238,7 @@ class Graph:
 
     def to_dict(self) -> dict:
         return {
+            "name": self.name,
             "type": self.graph_type.value,
             "nodes": [
                 {
@@ -258,7 +261,7 @@ class Graph:
     @classmethod
     def from_dict(cls, data: dict) -> "Graph":
 
-        graph = cls(GraphType(data["type"]))
+        graph = cls(data["name"], GraphType(data["type"]))
 
         node_map: dict[str, Node] = {}
 
@@ -285,6 +288,6 @@ class Graph:
 
     def __repr__(self) -> str:
         return (
-            f"Graph(type={self.graph_type.value}, "
+            f"Graph(name={self.name}, type={self.graph_type.value}, "
             f"nodes={len(self._nodes)}, edges={len(self._edges)})"
         )

--- a/src/nessie_api/models/tests/test_graph.py
+++ b/src/nessie_api/models/tests/test_graph.py
@@ -37,13 +37,13 @@ class TestGraph(unittest.TestCase):
         self.graph.add_node(self.node2)
         self.graph.add_edge(self.edge)
         graph_dict = self.graph.to_dict()
-        self.assertEqual(graph_dict["id"], "test_graph")
+        self.assertEqual(graph_dict["name"], "test_graph")
         self.assertEqual(len(graph_dict["nodes"]), 2)
         self.assertEqual(len(graph_dict["edges"]), 1)
 
     def test_deserialization(self):
         graph_dict = {
-            "id": "test_graph",
+            "name": "test_graph",
             "type": "directed",
             "nodes": [
                 {"id": "n1", "attributes": {}},
@@ -54,7 +54,7 @@ class TestGraph(unittest.TestCase):
             ]
         }
         graph = Graph.from_dict(graph_dict)
-        self.assertEqual(graph.id, "test_graph")
+        self.assertEqual(graph.name, "test_graph")
         self.assertEqual(len(graph.nodes), 2)
         self.assertEqual(len(graph.edges), 1)
 


### PR DESCRIPTION
Closes #9 

This pull request updates the `Graph` model to include a `name` attribute instead of an `id`, and ensures this attribute is properly serialized, deserialized, and tested. The changes improve clarity and consistency in how graphs are identified and handled throughout the codebase.

Model changes:

* Added a `name` attribute to the `Graph` class and removed the use of `id`. Updated the constructor to require `name` as a parameter.
* Updated the `to_dict` method to include the `name` field in the serialized dictionary.
* Modified the `from_dict` method to initialize `Graph` instances using the `name` field from the input dictionary.
* Updated the `__repr__` method to include the graph's `name` in its string representation.

Test updates:

* Updated tests to use the `name` field instead of `id` when checking serialization and deserialization of `Graph` objects. [[1]](diffhunk://#diff-75fb91ca2835d768ddc8344fa7de5b6d6cfc2ade36bf5324da7255495f9d6a9fL40-R46) [[2]](diffhunk://#diff-75fb91ca2835d768ddc8344fa7de5b6d6cfc2ade36bf5324da7255495f9d6a9fL57-R57)